### PR TITLE
multiple middleware hosts, configurable logging, optional group creation, ...

### DIFF
--- a/attributes/activemq.rb
+++ b/attributes/activemq.rb
@@ -1,0 +1,1 @@
+default['mcollective']['activemq']['heartbeat_interval'] = 30

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,6 +33,7 @@ default['mcollective']['group'] = 'mcollective'
 
 # Specify a version to install, or leave nil for latest
 default['mcollective']['package']['version'] = nil
+default['mcollective']['stomp_gem']['version'] = nil
 
 # Security provider plugin - psk/ssl/aes_security
 default['mcollective']['securityprovider'] = "psk"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -124,5 +124,5 @@ default['mcollective']['enable_puppetlabs_repo'] = false
 
 # Set package options to enable puppet repo
 if node['platform_family'] == 'rhel' && node['mcollective']['add_puppetlabs_repo']
-  node['mcollective']['package']['options'] = '--enablerepo=puppetlabs --enablerepo=puppetlabs-deps'
+  default['mcollective']['package']['options'] = '--enablerepo=puppetlabs --enablerepo=puppetlabs-deps'
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,17 +49,21 @@ default['mcollective']['connector']         = "activemq"
 # (see the MCollective documentation)
 default['mcollective']['direct_addressing'] = "y"
 
-# RabbitMQ details (used by rabbitmq connector)
-default['mcollective']['rabbitmq']['vhost'] = "/"
-
 # MCollective Identity and collective membership
 default['mcollective']['identity']        = node['fqdn']
 default['mcollective']['main_collective'] = "mcollective"
-default['mcollective']['collectives']     = "mcollective"
+default['mcollective']['collectives']     = [
+    'mcollective'
+]
 
 # Logging
+# types are 'file' or 'syslog'
+default['mcollective']['logger_type'] = "file"
+default['mcollective']['syslog_facility'] = "daemon"
 default['mcollective']['logfile'] = "/var/log/mcollective.log"
 default['mcollective']['loglevel'] = "info"
+default['mcollective']['keeplogs'] = 5
+default['mcollective']['max_log_size'] = nil
 
 # Locations
 default['mcollective']['site_plugins'] = "/etc/mcollective/site_plugins/mcollective"
@@ -76,7 +80,7 @@ default['mcollective']['plugin_conf'] = "/etc/mcollective/plugin.d"
 default['mcollective']['factsource']    = 'yaml'
 default['mcollective']['yaml_factfile'] = '/etc/mcollective/facts.yaml'
 
-default['mcollective']['classesfile']   = '/var/tmp/chefnode.txt'
+default['mcollective']['classesfile']   = '/var/chef/cache/chef_recipes.txt'
 
 # Ohai keys to include in the YAML fact list.
 default['mcollective']['fact_whitelist'] = [
@@ -94,7 +98,6 @@ default['mcollective']['fact_whitelist'] = [
                                             'uptime_seconds',
                                             'chef_packages',
                                             'keys',
-                                            'instmaint',
                                             'virtualization',
                                             'cpu',
                                             'memory'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -60,12 +60,14 @@ default['mcollective']['collectives']     = [
 
 # Logging
 # types are 'file' or 'syslog'
-default['mcollective']['logger_type'] = "file"
-default['mcollective']['syslog_facility'] = "daemon"
-default['mcollective']['logfile'] = "/var/log/mcollective.log"
-default['mcollective']['loglevel'] = "info"
-default['mcollective']['keeplogs'] = 5
-default['mcollective']['max_log_size'] = nil
+default['mcollective']['server']['logger_type'] = "file"
+default['mcollective']['server']['syslog_facility'] = "daemon"
+default['mcollective']['server']['logfile'] = "/var/log/mcollective.log"
+default['mcollective']['server']['loglevel'] = "info"
+default['mcollective']['server']['keeplogs'] = 5
+default['mcollective']['server']['max_log_size'] = nil
+default['mcollective']['client']['logger_type'] = "console"
+default['mcollective']['client']['loglevel'] = "info"
 
 # Locations
 default['mcollective']['site_plugins'] = "/etc/mcollective/site_plugins/mcollective"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,6 +31,7 @@ default['mcollective']['install_chef_application?'] = true
 
 # Name of the mcollective group
 default['mcollective']['group'] = 'mcollective'
+default['mcollective']['create_group?'] = true
 
 # Specify a version to install, or leave nil for latest
 default['mcollective']['package']['version'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -125,5 +125,7 @@ default['mcollective']['enable_puppetlabs_repo'] = false
 
 # Set package options to enable puppet repo
 if node['platform_family'] == 'rhel' && node['mcollective']['add_puppetlabs_repo']
-  default['mcollective']['package']['options'] = '--enablerepo=puppetlabs --enablerepo=puppetlabs-deps'
+  default['mcollective']['package']['options'] = '--assumeyes --enablerepo=puppetlabs --enablerepo=puppetlabs-deps'
+else
+  default['mcollective']['package']['options'] = '--assumeyes'
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,7 @@ default['mcollective']['users'] = []
 # this functionality, or are installing it another way.
 default['mcollective']['install_chef_agent?'] = true
 default['mcollective']['install_chef_handler?'] = true
+default['mcollective']['install_chef_application?'] = true
 
 # Name of the mcollective group
 default['mcollective']['group'] = 'mcollective'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -119,5 +119,10 @@ default['mcollective']['recipes']['install_server'] = 'mcollective::_install_ser
 # Recipe used to install client components
 default['mcollective']['recipes']['install_client'] = 'mcollective::_install_client_pkg'
 # Whether to enable the puppetlabs apt/yum repo when installing from packages.
-default['mcollective']['enable_puppetlabs_repo'] = true
+default['mcollective']['add_puppetlabs_repo'] = true
+default['mcollective']['enable_puppetlabs_repo'] = false
 
+# Set package options to enable puppet repo
+if node['platform_family'] == 'rhel' && node['mcollective']['add_puppetlabs_repo']
+  node['mcollective']['package']['options'] = '--enablerepo=puppetlabs --enablerepo=puppetlabs-deps'
+end

--- a/attributes/rabbitmq.rb
+++ b/attributes/rabbitmq.rb
@@ -1,0 +1,2 @@
+# RabbitMQ details (used by rabbitmq connector)
+default['mcollective']['rabbitmq']['vhost'] = "/"

--- a/attributes/stomp.rb
+++ b/attributes/stomp.rb
@@ -1,6 +1,6 @@
 # STOMP server details (used by stomp, rabbitmq and activemq connectors)
-default['mcollective']['stomp']['hostname'] = "localhost"
-default['mcollective']['stomp']['port'] = "6163"
+default['mcollective']['stomp']['hosts'] = ['localhost']
+default['mcollective']['stomp']['port'] = '61613'
 default['mcollective']['stomp']['username'] = "mcollective"
 default['mcollective']['stomp']['password'] = "marionette"
 default['mcollective']['stomp']['client_username'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "zts@cryptocracy.com"
 license          "Apache v2.0"
 name             "mcollective"
 description      "Provides the MCollective orchestration framework."
-version          "0.16.6"
+version          "0.16.7"
 
 %w{ debian ubuntu redhat centos amazon fedora scientific}.each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "zts@cryptocracy.com"
 license          "Apache v2.0"
 name             "mcollective"
 description      "Provides the MCollective orchestration framework."
-version          "0.16.4"
+version          "0.16.5"
 
 %w{ debian ubuntu redhat centos amazon fedora scientific}.each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "zts@cryptocracy.com"
 license          "Apache v2.0"
 name             "mcollective"
 description      "Provides the MCollective orchestration framework."
-version          "0.16.10"
+version          "0.16.11"
 
 %w{ debian ubuntu redhat centos amazon fedora scientific}.each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "zts@cryptocracy.com"
 license          "Apache v2.0"
 name             "mcollective"
 description      "Provides the MCollective orchestration framework."
-version          "0.16.8"
+version          "0.16.9"
 
 %w{ debian ubuntu redhat centos amazon fedora scientific}.each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "zts@cryptocracy.com"
 license          "Apache v2.0"
 name             "mcollective"
 description      "Provides the MCollective orchestration framework."
-version          "0.16.5"
+version          "0.16.6"
 
 %w{ debian ubuntu redhat centos amazon fedora scientific}.each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "zts@cryptocracy.com"
 license          "Apache v2.0"
 name             "mcollective"
 description      "Provides the MCollective orchestration framework."
-version          "0.16.9"
+version          "0.16.10"
 
 %w{ debian ubuntu redhat centos amazon fedora scientific}.each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "zts@cryptocracy.com"
 license          "Apache v2.0"
 name             "mcollective"
 description      "Provides the MCollective orchestration framework."
-version          "0.16.2"
+version          "0.16.3"
 
 %w{ debian ubuntu redhat centos amazon fedora scientific}.each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "zts@cryptocracy.com"
 license          "Apache v2.0"
 name             "mcollective"
 description      "Provides the MCollective orchestration framework."
-version          "0.16.0"
+version          "0.16.1"
 
 %w{ debian ubuntu redhat centos amazon fedora scientific}.each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "zts@cryptocracy.com"
 license          "Apache v2.0"
 name             "mcollective"
 description      "Provides the MCollective orchestration framework."
-version          "0.16.11"
+version          "0.16.12"
 
 %w{ debian ubuntu redhat centos amazon fedora scientific}.each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "zts@cryptocracy.com"
 license          "Apache v2.0"
 name             "mcollective"
 description      "Provides the MCollective orchestration framework."
-version          "0.16.3"
+version          "0.16.4"
 
 %w{ debian ubuntu redhat centos amazon fedora scientific}.each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "zts@cryptocracy.com"
 license          "Apache v2.0"
 name             "mcollective"
 description      "Provides the MCollective orchestration framework."
-version          "0.16.7"
+version          "0.16.8"
 
 %w{ debian ubuntu redhat centos amazon fedora scientific}.each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "zts@cryptocracy.com"
 license          "Apache v2.0"
 name             "mcollective"
 description      "Provides the MCollective orchestration framework."
-version          "0.15.0"
+version          "0.16.0"
 
 %w{ debian ubuntu redhat centos amazon fedora scientific}.each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "zts@cryptocracy.com"
 license          "Apache v2.0"
 name             "mcollective"
 description      "Provides the MCollective orchestration framework."
-version          "0.16.12"
+version          "0.16.13"
 
 %w{ debian ubuntu redhat centos amazon fedora scientific}.each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "zts@cryptocracy.com"
 license          "Apache v2.0"
 name             "mcollective"
 description      "Provides the MCollective orchestration framework."
-version          "0.16.1"
+version          "0.16.2"
 
 %w{ debian ubuntu redhat centos amazon fedora scientific}.each do |os|
   supports os

--- a/recipes/_install_client_pkg.rb
+++ b/recipes/_install_client_pkg.rb
@@ -21,4 +21,5 @@
 package "mcollective-client" do
   action :install
   version node['mcollective']['package']['version']
+  options node['mcollective']['package']['options']
 end

--- a/recipes/_install_common_pkg.rb
+++ b/recipes/_install_common_pkg.rb
@@ -37,6 +37,8 @@ package "rubygem-stomp" do
   action :install
 end
 
+pp node['mcollective']
+
 package "mcollective-common" do
   action :install
   version node['mcollective']['package']['version']

--- a/recipes/_install_common_pkg.rb
+++ b/recipes/_install_common_pkg.rb
@@ -42,3 +42,16 @@ package "mcollective-common" do
   version node['mcollective']['package']['version']
   options node['mcollective']['package']['options']
 end
+
+if node['platform'] == 'amazon'
+  link '/usr/local/share/ruby/site_ruby/2.0/mcollective' do
+    to '/usr/lib/ruby/site_ruby/1.8/mcollective'
+  end
+  link '/usr/local/share/ruby/site_ruby/2.0/mcollective.rb' do
+    to '/usr/lib/ruby/site_ruby/1.8/mcollective.rb'
+  end
+  gem_package 'stomp' do
+    action  :install
+    version node['mcollective']['stomp_gem']['version']
+  end
+end

--- a/recipes/_install_common_pkg.rb
+++ b/recipes/_install_common_pkg.rb
@@ -37,8 +37,6 @@ package "rubygem-stomp" do
   action :install
 end
 
-pp node['mcollective']
-
 package "mcollective-common" do
   action :install
   version node['mcollective']['package']['version']

--- a/recipes/_install_common_pkg.rb
+++ b/recipes/_install_common_pkg.rb
@@ -18,7 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if node['mcollective']['enable_puppetlabs_repo']
+if node['mcollective']['add_puppetlabs_repo'] || node['mcollective']['enable_puppetlabs_repo']
   include_recipe 'mcollective::puppetlabs-repo'
 end
 
@@ -32,6 +32,7 @@ package "rubygem-stomp" do
     package_name "libstomp-ruby"
   when "rhel","fedora"
     package_name "rubygem-stomp"
+    options node['mcollective']['package']['options']
   end
   action :install
 end
@@ -39,4 +40,5 @@ end
 package "mcollective-common" do
   action :install
   version node['mcollective']['package']['version']
+  options node['mcollective']['package']['options']
 end

--- a/recipes/_install_server_pkg.rb
+++ b/recipes/_install_server_pkg.rb
@@ -21,4 +21,5 @@
 package "mcollective" do
   action :install
   version node['mcollective']['package']['version']
+  options node['mcollective']['package']['options']
 end

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -34,3 +34,10 @@ template "/etc/mcollective/client.cfg" do
   variables :site_plugins => site_libdir,
             :config       => node['mcollective']
 end
+
+# mco client application
+cookbook_file "#{node['mcollective']['site_plugins']}/application/chef.rb" do
+  source "plugins/application/chef.rb"
+  mode '0644'
+  only_if { node['mcollective']['install_chef_application?'] }
+end

--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -66,36 +66,31 @@ end
 
 ## plugin configuration files
 # stomp connector
-template "#{node['mcollective']['plugin_conf']}/stomp.cfg" do
-  source "plugin-stomp.cfg.erb"
-  owner 'root'
-  group node['mcollective']['group']
-  mode '0640'
-  variables :stomp => node['mcollective']['stomp']
-end
+case node['mcollective']['connector']:
+when 'activemq':
+  # activemq connector
+  template "#{node['mcollective']['plugin_conf']}/activemq.cfg" do
+    source "plugin-activemq.cfg.erb"
+    owner 'root'
+    group node['mcollective']['group']
+    mode '0640'
+    variables :stomp => node['mcollective']['stomp'],
+              :activemq => node['mcollective']['activemq']
+  end
 
-# activemq connector
-template "#{node['mcollective']['plugin_conf']}/activemq.cfg" do
-  source "plugin-activemq.cfg.erb"
-  owner 'root'
-  group node['mcollective']['group']
-  mode '0640'
-  variables :stomp => node['mcollective']['stomp']
-end
+when 'rabbitmq':
+  # rabbitmq connector
+  template "#{node['mcollective']['plugin_conf']}/rabbitmq.cfg" do
+    source "plugin-rabbitmq.cfg.erb"
+    owner 'root'
+    group node['mcollective']['group']
+    mode '0640'
+    variables :stomp => node['mcollective']['stomp'],
+              :rabbitmq => node['mcollective']['rabbitmq']
+  end
 
-# rabbitmq connector
-template "#{node['mcollective']['plugin_conf']}/rabbitmq.cfg" do
-  source "plugin-rabbitmq.cfg.erb"
-  owner 'root'
-  group node['mcollective']['group']
-  mode '0640'
-  variables :stomp => node['mcollective']['stomp'],
-            :rabbitmq => node['mcollective']['rabbitmq']
-end
-
-# redis connector
-if node['mcollective']['connector'] == 'redis'
-  # install the connector
+when 'redis':
+  # redis connector
   gem_package "redis"
   remote_file "#{node['mcollective']['site_plugins']}/connector/redis.rb" do
     source "https://github.com/ripienaar/mc-plugins/raw/master/connector/redis/redis.rb"

--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -65,6 +65,7 @@ when 'activemq'
     mode '0640'
     variables :stomp => node['mcollective']['stomp'],
               :activemq => node['mcollective']['activemq']
+    notifies :restart, 'service[mcollective]', :delayed
   end
 
 when 'rabbitmq'
@@ -76,6 +77,7 @@ when 'rabbitmq'
     mode '0640'
     variables :stomp => node['mcollective']['stomp'],
               :rabbitmq => node['mcollective']['rabbitmq']
+    notifies :restart, 'service[mcollective]', :delayed
   end
 
 when 'redis'
@@ -93,5 +95,6 @@ when 'redis'
     group node['mcollective']['group']
     mode '0640'
     variables :redis => node['mcollective']['redis']
+    notifies :restart, 'service[mcollective]', :delayed
   end
 end

--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -66,8 +66,8 @@ end
 
 ## plugin configuration files
 # stomp connector
-case node['mcollective']['connector']:
-when 'activemq':
+case node['mcollective']['connector']
+when 'activemq'
   # activemq connector
   template "#{node['mcollective']['plugin_conf']}/activemq.cfg" do
     source "plugin-activemq.cfg.erb"
@@ -78,7 +78,7 @@ when 'activemq':
               :activemq => node['mcollective']['activemq']
   end
 
-when 'rabbitmq':
+when 'rabbitmq'
   # rabbitmq connector
   template "#{node['mcollective']['plugin_conf']}/rabbitmq.cfg" do
     source "plugin-rabbitmq.cfg.erb"
@@ -89,7 +89,7 @@ when 'rabbitmq':
               :rabbitmq => node['mcollective']['rabbitmq']
   end
 
-when 'redis':
+when 'redis'
   # redis connector
   gem_package "redis"
   remote_file "#{node['mcollective']['site_plugins']}/connector/redis.rb" do

--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -25,7 +25,7 @@ include_recipe node['mcollective']['recipes']['install_common']
 group node['mcollective']['group'] do
   members node['mcollective']['users']
   action :create
-  only_if node['mcollective']['create_group?']
+  only_if { node['mcollective']['create_group?'] }
 end
 
 # directories for unpackaged plugins (extra mcollective libdir)

--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -25,6 +25,7 @@ include_recipe node['mcollective']['recipes']['install_common']
 group node['mcollective']['group'] do
   members node['mcollective']['users']
   action :create
+  only_if node['mcollective']['create_group?']
 end
 
 # directories for unpackaged plugins (extra mcollective libdir)

--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -28,7 +28,7 @@ group node['mcollective']['group'] do
 end
 
 # directories for unpackaged plugins (extra mcollective libdir)
-plugin_types = %w{agent audit connector data facts registration security simplerpc_authorization}
+plugin_types = %w{agent application audit connector data facts registration security simplerpc_authorization}
 plugin_types.each do |dir|
   directory "#{node['mcollective']['site_plugins']}/#{dir}" do
     owner 'root'
@@ -38,22 +38,10 @@ plugin_types.each do |dir|
   end
 end
 
-# install chef agent
-cookbook_file "#{node['mcollective']['site_plugins']}/agent/chef.rb" do
-  source "plugins/agent/chef.rb"
-  mode '0644'
-  if resource(:service => 'mcollective')
-    notifies :restart, "service[mcollective]"
-  end rescue Chef::Exceptions::ResourceNotFound
-  only_if { node['mcollective']['install_chef_agent?'] }
-end
+# install chef DDL file
 cookbook_file "#{node['mcollective']['site_plugins']}/agent/chef.ddl" do
   source "plugins/agent/chef.ddl"
   mode '0644'
-  if resource(:service => 'mcollective')
-    notifies :restart, "service[mcollective]"
-  end rescue Chef::Exceptions::ResourceNotFound
-  only_if { node['mcollective']['install_chef_agent?'] }
 end
 
 # directory for per-plugin configuration (plugin.d)

--- a/recipes/puppetlabs-repo.rb
+++ b/recipes/puppetlabs-repo.rb
@@ -51,26 +51,30 @@ when "rhel"
     yum_cookbook_3 = true
   end
 
-  # on amazon linux, $releasever is "latest", which the repo doesn't support
-  if platform?("amazon")
-    release = "6Server"
+  # on amazon linux, $releasever is "latest" or a date, which the repo doesn't support
+  if platform?('amazon')
+    release = '6'
   else
-    release = "$releasever"
+    release = '$releasever'
   end
 
   yum_repository "puppetlabs" do
     name "puppetlabs"
     description "Puppet Labs Packages"
-    url "http://yum.puppetlabs.com/el/#{release}/products/$basearch"
+    baseurl "http://yum.puppetlabs.com/el/#{release}/products/$basearch"
+    gpgcheck true
     gpgkey "http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs" if yum_cookbook_3
+    enabled node['mcollective']['enable_puppetlabs_repo']
     action :add
   end
 
   yum_repository "puppetlabs-deps" do
     name "puppetlabs-deps"
     description "Dependencies for Puppet Labs Software"
-    url "http://yum.puppetlabs.com/el/#{release}/dependencies/$basearch"
+    baseurl "http://yum.puppetlabs.com/el/#{release}/dependencies/$basearch"
+    gpgcheck true
     gpgkey "http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs" if yum_cookbook_3
+    enabled node['mcollective']['enable_puppetlabs_repo']
     action :add
   end
 when "fedora"
@@ -87,15 +91,19 @@ when "fedora"
   yum_repository "puppetlabs" do
     name "puppetlabs"
     description "Puppet Labs Packages"
-    url "http://yum.puppetlabs.com/fedora/f$releasever/products/$basearch"
+    baseurl "http://yum.puppetlabs.com/fedora/f$releasever/products/$basearch"
+    gpgcheck true
     gpgkey "http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs" if yum_cookbook_3
+    enabled node['mcollective']['enable_puppetlabs_repo']
     action :add
   end
   yum_repository "puppetlabs-deps" do
     name "puppetlabs-deps"
     description "Dependencies for Puppet Labs Software"
-    url "http://yum.puppetlabs.com/fedora/$releasever/dependencies/$basearch"
+    baseurl "http://yum.puppetlabs.com/fedora/$releasever/dependencies/$basearch"
+    gpgcheck true
     gpgkey "http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs" if yum_cookbook_3
+    enabled node['mcollective']['enable_puppetlabs_repo']
     action :add
   end
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -54,6 +54,14 @@ if node['mcollective']['install_chef_handler?']
   end
 end
 
+# install chef agent
+cookbook_file "#{node['mcollective']['site_plugins']}/agent/chef.rb" do
+  source "plugins/agent/chef.rb"
+  mode '0644'
+  notifies :restart, "service[mcollective]", :delayed
+  only_if { node['mcollective']['install_chef_agent?'] }
+end
+
 service "mcollective" do
   supports :restart => true, :status => true
   # Restart mcollective if the chef agent changes

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -68,7 +68,7 @@ describe 'mcollective::common' do
     let(:chef_run) {
       chef_run = ChefSpec::Runner.new(:platform => 'redhat', :version => '6.3')
       chef_run.node.set['mcollective']['connector'] = 'activemq'
-      chef_run.node.set['mcollective']['stomp']['hostname'] = 'testhost'
+      chef_run.node.set['mcollective']['stomp']['hosts'] = ['testhost']
       chef_run.node.set['mcollective']['stomp']['port'] = '12345'
       chef_run.node.set['mcollective']['stomp']['username'] = 'testuser'
       chef_run.node.set['mcollective']['stomp']['password'] = 'testpass'
@@ -95,7 +95,7 @@ describe 'mcollective::common' do
     let(:chef_run) {
       chef_run = ChefSpec::Runner.new(:platform => 'redhat', :version => '6.3')
       chef_run.node.set['mcollective']['connector'] = 'rabbitmq'
-      chef_run.node.set['mcollective']['stomp']['hostname'] = 'testhost'
+      chef_run.node.set['mcollective']['stomp']['hosts'] = ['testhost']
       chef_run.node.set['mcollective']['stomp']['port'] = '12345'
       chef_run.node.set['mcollective']['stomp']['username'] = 'testuser'
       chef_run.node.set['mcollective']['stomp']['password'] = 'testpass'

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -66,7 +66,7 @@ describe 'mcollective::server' do
     let(:chef_run) {
       chef_run = ChefSpec::Runner.new(:platform => 'redhat', :version => '6.3')
       chef_run.node.set['mcollective']['connector'] = 'activemq'
-      chef_run.node.set['mcollective']['stomp']['hostname'] = 'testhost'
+      chef_run.node.set['mcollective']['stomp']['hosts'] = ['testhost']
       chef_run.node.set['mcollective']['stomp']['port'] = '12345'
       chef_run.node.set['mcollective']['stomp']['username'] = 'testuser'
       chef_run.node.set['mcollective']['stomp']['password'] = 'testpass'
@@ -90,7 +90,7 @@ describe 'mcollective::server' do
     let(:chef_run) {
       chef_run = ChefSpec::Runner.new(:platform => 'redhat', :version => '6.3')
       chef_run.node.set['mcollective']['connector'] = 'rabbitmq'
-      chef_run.node.set['mcollective']['stomp']['hostname'] = 'testhost'
+      chef_run.node.set['mcollective']['stomp']['hosts'] = ['testhost']
       chef_run.node.set['mcollective']['stomp']['port'] = '12345'
       chef_run.node.set['mcollective']['stomp']['username'] = 'testuser'
       chef_run.node.set['mcollective']['stomp']['password'] = 'testpass'

--- a/templates/default/client.cfg.erb
+++ b/templates/default/client.cfg.erb
@@ -12,10 +12,8 @@ logger_type = <%= @config['client']['logger_type'] %>
 loglevel = <%= @config['client']['loglevel'] %>
 <% if( @config['client']['logger_type'] == 'syslog' ) then -%>
 logfacility = <%= @config['client']['syslog_facility'] %>
-<% end -%>
-<% if( @config['client']['logger_type'] == 'file' ) then -%>
+<% elsif( @config['client']['logger_type'] == 'file' ) then -%>
 logfile = <%= @config['client']['logfile'] %>
-<% end -%>
 <% end -%>
 
 # Plugins

--- a/templates/default/client.cfg.erb
+++ b/templates/default/client.cfg.erb
@@ -19,7 +19,7 @@ plugin.psk.callertype = <%= @config['psk_callertype'] %>
 connector = <%= @config['connector'] %>
 <% if ['activemq','rabbitmq'].include?(@config['connector'])
    @config['stomp']['hosts'].each_with_index do |hostname, index| -%>
-plugin.<%= @config['connector'] %>.pool.<%= index+1 -%>.user = <%= @config['stomp']['client_password'] || @config['stomp']['password'] %>
+plugin.<%= @config['connector'] %>.pool.<%= index+1 -%>.user = <%= @config['stomp']['client_username'] || @config['stomp']['username'] %>
 plugin.<%= @config['connector'] %>.pool.<%= index+1 -%>.password = <%= @config['stomp']['client_password'] || @config['stomp']['password'] %>
 <% end end -%>
 

--- a/templates/default/client.cfg.erb
+++ b/templates/default/client.cfg.erb
@@ -17,6 +17,11 @@ plugin.psk.callertype = <%= @config['psk_callertype'] %>
 <%- end %>
 
 connector = <%= @config['connector'] %>
+<% if ['activemq','rabbitmq'].include?(@config['connector'])
+   @config['stomp']['hosts'].each_with_index do |hostname, index| -%>
+plugin.<%= @config['connector'] %>.pool.<%= index+1 -%>.user = <%= @config['stomp']['client_password'] || @config['stomp']['password'] %>
+plugin.<%= @config['connector'] %>.pool.<%= index+1 -%>.password = <%= @config['stomp']['client_password'] || @config['stomp']['password'] %>
+<% end end -%>
 
 # Facts
 <% if @config['factsource'] == 'ohai' %>

--- a/templates/default/client.cfg.erb
+++ b/templates/default/client.cfg.erb
@@ -1,8 +1,8 @@
-<%- if @config['connector'] == 'stomp' %>
+<% if @config['connector'] == 'stomp' -%>
 topicprefix = /topic/
-<%- end %>
+<% end -%>
 main_collective = <%= @config['main_collective'] %>
-collectives = <%= @config['collectives'] %>
+collectives = <%= @config['collectives'].join(',') %>
 direct_addressing = <%= @config['direct_addressing'] %>
 identity = <%= @config['identity'] %>
 libdir = <%= @site_plugins %>:<%= @config['libdir'] %>
@@ -17,10 +17,6 @@ plugin.psk.callertype = <%= @config['psk_callertype'] %>
 <%- end %>
 
 connector = <%= @config['connector'] %>
-<%- if ['activemq','rabbitmq'].include?(@config['connector']) %>
-plugin.<%= @config['connector'] %>.pool.1.user = <%= @config['stomp']['client_username'] || @config['stomp']['username'] %>
-plugin.<%= @config['connector'] %>.pool.1.password = <%= @config['stomp']['client_password'] || @config['stomp']['password'] %>
-<%- end %>
 
 # Facts
 <% if @config['factsource'] == 'ohai' %>

--- a/templates/default/client.cfg.erb
+++ b/templates/default/client.cfg.erb
@@ -6,8 +6,17 @@ collectives = <%= @config['collectives'].join(',') %>
 direct_addressing = <%= @config['direct_addressing'] %>
 identity = <%= @config['identity'] %>
 libdir = <%= @site_plugins %>:<%= @config['libdir'] %>
-logfile = /dev/null
-loglevel = info
+
+# Logging
+logger_type = <%= @config['client']['logger_type'] %>
+loglevel = <%= @config['client']['loglevel'] %>
+<% if( @config['client']['logger_type'] == 'syslog' ) then -%>
+logfacility = <%= @config['client']['syslog_facility'] %>
+<% end -%>
+<% if( @config['client']['logger_type'] == 'file' ) then -%>
+logfile = <%= @config['client']['logfile'] %>
+<% end -%>
+<% end -%>
 
 # Plugins
 securityprovider = <%= @config['securityprovider'] %>

--- a/templates/default/plugin-activemq.cfg.erb
+++ b/templates/default/plugin-activemq.cfg.erb
@@ -1,7 +1,12 @@
-pool.size = 1
-pool.1.host = <%= @stomp['hostname'] %>
-pool.1.port = <%= @stomp['port'] %>
+pool.size = <%= @stomp['hosts'].length %>
+<% @stomp['hosts'].each_with_index do |hostname, index| -%>
+pool.<%= index+1 -%>.host = <%= hostname %>
+pool.<%= index+1 -%>.port = <%= @stomp['port'] %>
+pool.<%= index+1 -%>.user = <%= @stomp['username'] %>
+pool.<%= index+1 -%>.password = <%= @stomp['password'] %>
+<% end -%>
 
+heartbeat_interval = <%= @activemq['heartbeat_interval'] %>
 initial_reconnect_delay = 0.01
 max_reconnect_delay = 30.0
 use_exponential_back_off = true

--- a/templates/default/plugin-activemq.cfg.erb
+++ b/templates/default/plugin-activemq.cfg.erb
@@ -2,8 +2,6 @@ pool.size = <%= @stomp['hosts'].length %>
 <% @stomp['hosts'].each_with_index do |hostname, index| -%>
 pool.<%= index+1 -%>.host = <%= hostname %>
 pool.<%= index+1 -%>.port = <%= @stomp['port'] %>
-pool.<%= index+1 -%>.user = <%= @stomp['username'] %>
-pool.<%= index+1 -%>.password = <%= @stomp['password'] %>
 <% end -%>
 
 heartbeat_interval = <%= @activemq['heartbeat_interval'] %>

--- a/templates/default/plugin-rabbitmq.cfg.erb
+++ b/templates/default/plugin-rabbitmq.cfg.erb
@@ -1,5 +1,9 @@
-pool.size = 1
-pool.1.host = <%= @stomp['hostname'] %>
-pool.1.port = <%= @stomp['port'] %>
+pool.size = <%= @stomp['hosts'].length %>
+<% @stomp['hosts'].each_with_index do |hostname, index| -%>
+pool.<%= index+1 -%>.host = <%= hostname %>
+pool.<%= index+1 -%>.port = <%= @stomp['port'] %>
+pool.<%= index+1 -%>.user = <%= @stomp['username'] %>
+pool.<%= index+1 -%>.password = <%= @stomp['password'] %>
+<% end -%>
 
 vhost = <%= @rabbitmq['vhost'] %>

--- a/templates/default/plugin-stomp.cfg.erb
+++ b/templates/default/plugin-stomp.cfg.erb
@@ -1,4 +1,0 @@
-host = <%= @stomp['hostname'] %>
-port = <%= @stomp['port'] %>
-user = <%= @stomp['username'] %>
-password = <%= @stomp['password'] %>

--- a/templates/default/server.cfg.erb
+++ b/templates/default/server.cfg.erb
@@ -8,18 +8,18 @@ identity = <%= @config['identity'] %>
 libdir = <%= @site_plugins %>:<%= @config['libdir'] %>
 
 # Logging
-logger_type = <%= @config['logger_type'] %>
-loglevel = <%= @config['loglevel'] %>
-<% if( @config['logger_type'] == 'syslog' ) then -%>
-logfacility = <%= @config['syslog_facility'] %>
+logger_type = <%= @config['server']['logger_type'] %>
+loglevel = <%= @config['server']['loglevel'] %>
+<% if( @config['server']['logger_type'] == 'syslog' ) then -%>
+logfacility = <%= @config['server']['syslog_facility'] %>
 <% end -%>
-<% if( @config['logger_type'] == 'file' ) then -%>
-logfile = <%= @config['logfile'] %>
-<% if( @config['keeplogs'] ) then -%>
-keeplogs = <%= @config['keeplogs'] %>
+<% if( @config['server']['logger_type'] == 'file' ) then -%>
+logfile = <%= @config['server']['logfile'] %>
+<% if( @config['server']['keeplogs'] ) then -%>
+keeplogs = <%= @config['server']['keeplogs'] %>
 <% end -%>
-<% if( @config['max_log_size'] ) then -%>
-max_log_size = <%= @config['max_log_size'] %>
+<% if( @config['server']['max_log_size'] ) then -%>
+max_log_size = <%= @config['server']['max_log_size'] %>
 <% end -%>
 <% end -%>
 

--- a/templates/default/server.cfg.erb
+++ b/templates/default/server.cfg.erb
@@ -12,8 +12,7 @@ logger_type = <%= @config['server']['logger_type'] %>
 loglevel = <%= @config['server']['loglevel'] %>
 <% if( @config['server']['logger_type'] == 'syslog' ) then -%>
 logfacility = <%= @config['server']['syslog_facility'] %>
-<% end -%>
-<% if( @config['server']['logger_type'] == 'file' ) then -%>
+<% elsif( @config['server']['logger_type'] == 'file' ) then -%>
 logfile = <%= @config['server']['logfile'] %>
 <% if( @config['server']['keeplogs'] ) then -%>
 keeplogs = <%= @config['server']['keeplogs'] %>

--- a/templates/default/server.cfg.erb
+++ b/templates/default/server.cfg.erb
@@ -33,6 +33,11 @@ plugin.psk.callertype = <%= @config['psk_callertype'] %>
 <%- end %>
 
 connector = <%= @config['connector'] %>
+<% if ['activemq','rabbitmq'].include?(@config['connector'])
+   @config['stomp']['hosts'].each_with_index do |hostname, index| -%>
+plugin.<%= @config['connector'] %>.pool.<%= index+1 -%>.user = <%= @config['stomp']['password'] %>
+plugin.<%= @config['connector'] %>.pool.<%= index+1 -%>.password = <%= @config['stomp']['password'] %>
+<% end end -%>
 
 # Facts
 <% if @config['factsource'] == 'ohai' %>

--- a/templates/default/server.cfg.erb
+++ b/templates/default/server.cfg.erb
@@ -35,7 +35,7 @@ plugin.psk.callertype = <%= @config['psk_callertype'] %>
 connector = <%= @config['connector'] %>
 <% if ['activemq','rabbitmq'].include?(@config['connector'])
    @config['stomp']['hosts'].each_with_index do |hostname, index| -%>
-plugin.<%= @config['connector'] %>.pool.<%= index+1 -%>.user = <%= @config['stomp']['password'] %>
+plugin.<%= @config['connector'] %>.pool.<%= index+1 -%>.user = <%= @config['stomp']['username'] %>
 plugin.<%= @config['connector'] %>.pool.<%= index+1 -%>.password = <%= @config['stomp']['password'] %>
 <% end end -%>
 

--- a/templates/default/server.cfg.erb
+++ b/templates/default/server.cfg.erb
@@ -2,12 +2,27 @@
 topicprefix = /topic/
 <%- end %>
 main_collective = <%= @config['main_collective'] %>
-collectives = <%= @config['collectives'] %>
+collectives = <%= @config['collectives'].join(',') %>
 direct_addressing = <%= @config['direct_addressing'] %>
 identity = <%= @config['identity'] %>
 libdir = <%= @site_plugins %>:<%= @config['libdir'] %>
-logfile = <%= @config['logfile'] %>
+
+# Logging
+logger_type = <%= @config['logger_type'] %>
 loglevel = <%= @config['loglevel'] %>
+<% if( @config['logger_type'] == 'syslog' ) then -%>
+logfacility = <%= @config['syslog_facility'] %>
+<% end -%>
+<% if( @config['logger_type'] == 'file' ) then -%>
+logfile = <%= @config['logfile'] %>
+<% if( @config['keeplogs'] ) then -%>
+keeplogs = <%= @config['keeplogs'] %>
+<% end -%>
+<% if( @config['max_log_size'] ) then -%>
+max_log_size = <%= @config['max_log_size'] %>
+<% end -%>
+<% end -%>
+
 daemonize = 1
 
 # Plugins
@@ -18,11 +33,6 @@ plugin.psk.callertype = <%= @config['psk_callertype'] %>
 <%- end %>
 
 connector = <%= @config['connector'] %>
-<%- if ['activemq','rabbitmq'].include?(@config['connector']) %>
-plugin.<%= @config['connector'] %>.pool.1.user = <%= @config['stomp']['username'] %>
-plugin.<%= @config['connector'] %>.pool.1.password = <%= @config['stomp']['password'] %>
-<%- end %>
-
 
 # Facts
 <% if @config['factsource'] == 'ohai' %>


### PR DESCRIPTION
Restructure collectives and middleware hosts into arrays to take advantage of attribute merging.
Output multiple middleware hosts in connector config files.
Add syslog logging and logfile management config options.
Remove obsolete stomp plugin.
Add activemq heartbeat configuration.
Change default STOMP port to standardized 61613.
make creation of the group optional to allow pre-existing groups
Optionally install the mco client application
Add the ability to install puppetlabs repos without enabling them.
Enable download of GPG key without complaint
Setup symlinks, install stomp gem so that Amazon Linux works
